### PR TITLE
Fix MPC config parsing and improve error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ configGlobal.toml
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# Logs
+*.log
+
 # main executable
 sfkit-proxy

--- a/ice/ice.go
+++ b/ice/ice.go
@@ -518,7 +518,7 @@ func (s *Service) handleRemoteCredential(a *ice.Agent, msg Message, conns chan<-
 
 	iceOpType := "Accept"
 	iceOp := a.Accept
-	if s.mpc.IsControlling(msg.SourcePID) {
+	if s.mpc.IsClient(msg.SourcePID) {
 		slog.Debug("Dialing ICE candidate", "remotePID", msg.SourcePID)
 		iceOpType = "Dial"
 		iceOp = a.Dial

--- a/mpc/mpc.go
+++ b/mpc/mpc.go
@@ -18,10 +18,7 @@ type Config struct {
 	// ServerPIDs maps remote server address:port to remote server PID
 	ServerPIDs map[netip.AddrPort]PID
 
-	// PIDServers maps remote server PID to remote server address:port(s)
-	PIDServers map[PID][]netip.AddrPort
-
-	// PIDClients maps remote client PID to local server address:port(s)
+	// PIDClients maps remote client PID to local server address:port
 	PIDClients map[PID][]netip.AddrPort
 
 	// PeerPIDs is a list of all remote PIDs that are
@@ -32,14 +29,8 @@ type Config struct {
 	Threads  int
 }
 
-// IsControlling returns true iff the local ICE agent is controlling for the peer PID.
-func (c *Config) IsControlling(peerPID PID) bool {
-	return c.LocalPID > peerPID
-}
-
-// IsClient returns true iff the local PID is a client to the peer PID.
 func (c *Config) IsClient(peerPID PID) bool {
-	return len(c.PIDServers[peerPID]) > 0
+	return c.LocalPID > peerPID
 }
 
 // ParseConfig parses MPC TOML config file,
@@ -52,7 +43,6 @@ func ParseConfig(configPath string, localPID PID) (c *Config, err error) {
 	c = &Config{
 		LocalPID:   localPID,
 		ServerPIDs: make(map[netip.AddrPort]PID),
-		PIDServers: make(map[PID][]netip.AddrPort),
 		PIDClients: make(map[PID][]netip.AddrPort),
 		Threads:    tc.MpcNumThreads,
 	}
@@ -78,7 +68,6 @@ func ParseConfig(configPath string, localPID PID) (c *Config, err error) {
 					c.PIDClients[clientPID] = append(c.PIDClients[clientPID], ap)
 					peerPIDs[clientPID] = true
 				case clientPID:
-					c.PIDServers[serverPID] = append(c.PIDServers[serverPID], ap)
 					c.ServerPIDs[ap] = serverPID
 					peerPIDs[serverPID] = true
 				}

--- a/mpc/mpc.go
+++ b/mpc/mpc.go
@@ -63,13 +63,15 @@ func ParseConfig(configPath string, localPID PID) (c *Config, err error) {
 				return
 			}
 			for t := 0; t < tc.MpcNumThreads; t++ {
-				switch localPID {
-				case serverPID:
+				switch true {
+				case localPID == serverPID && !c.IsClient(clientPID):
 					c.PIDClients[clientPID] = append(c.PIDClients[clientPID], ap)
 					peerPIDs[clientPID] = true
-				case clientPID:
+				case localPID == clientPID && c.IsClient(serverPID):
 					c.ServerPIDs[ap] = serverPID
 					peerPIDs[serverPID] = true
+				default:
+					continue
 				}
 				ap = netip.AddrPortFrom(ap.Addr(), ap.Port()+1)
 			}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -242,6 +242,12 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 			// }
 
 			// retry all errors for now
+			if err == nil {
+				// exponential retry
+				err = localEOF
+			} else if err != nil {
+				slog.Error("Error copying local <- remote:", "err", err)
+			}
 			return
 		}))
 
@@ -261,6 +267,12 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 			// }
 
 			// retry all errors for now
+			if err == nil {
+				// exponential retry
+				err = localEOF
+			} else if err != nil {
+				slog.Error("Error copying local -> remote:", "err", err)
+			}
 			return
 		}))
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -229,17 +229,19 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 		util.Go(ctx, errs, util.Retry(ctx, func() (err error) {
 			nbytes, err := io.Copy(localConn, remoteConn)
 			slog.Debug("Copied local <- remote:", "b", nbytes, "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", err)
-			if err == io.EOF {
-				// err == io.EOF means local connection was closed,
-				// so we should exit and retry after recreating it
-				return util.Permanent(localEOF)
-			} else if err == nil {
-				// err == nil means remote connection was closed,
-				// which is not expected so we give up
-				return util.Permanent(io.EOF)
-			} else {
-				slog.Error("Error copying local <- remote:", "err", err)
-			}
+			// if err == io.EOF {
+			// 	// err == io.EOF means local connection was closed,
+			// 	// so we should exit and retry after recreating it
+			// 	return util.Permanent(localEOF)
+			// } else if err == nil {
+			// 	// err == nil means remote connection was closed,
+			// 	// which is not expected so we give up
+			// 	return util.Permanent(io.EOF)
+			// } else {
+			// 	slog.Error("Error copying local <- remote:", "err", err)
+			// }
+
+			// retry all errors for now
 			return
 		}))
 
@@ -247,16 +249,18 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 		util.Go(ctx, errs, util.Retry(ctx, func() (err error) {
 			nbytes, err := io.Copy(remoteConn, localConn)
 			slog.Debug("Copied local -> remote:", "b", nbytes, "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", err)
-			if err == nil {
-				// err == nil means local connection was closed,
-				// so we should exit and retry after recreating it
-				return util.Permanent(localEOF)
-			}
-			if err == io.EOF {
-				err = util.Permanent(err)
-			} else {
-				slog.Error("Error copying local -> remote:", "err", err)
-			}
+			// if err == nil {
+			// 	// err == nil means local connection was closed,
+			// 	// so we should exit and retry after recreating it
+			// 	return util.Permanent(localEOF)
+			// }
+			// if err == io.EOF {
+			// 	err = util.Permanent(err)
+			// } else {
+			// 	slog.Error("Error copying local -> remote:", "err", err)
+			// }
+
+			// retry all errors for now
 			return
 		}))
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -226,6 +226,8 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 				return localEOF
 			} else if err == nil {
 				err = util.Permanent(io.EOF)
+			} else {
+				slog.Error("Error copying local <- remote:", "err", err)
 			}
 			return
 		}))
@@ -241,6 +243,8 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 			}
 			if err == io.EOF {
 				err = util.Permanent(err)
+			} else if err != nil {
+				slog.Error("Error copying local -> remote:", "err", err)
 			}
 			return
 		}))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -311,6 +311,6 @@ func getLocalConn(localAddrs []netip.AddrPort, rc net.Conn) (lc *net.TCPConn, er
 		return
 	}
 	lc = c.(*net.TCPConn)
-	slog.Debug("Dialed local listener:", "localAddr", lc.RemoteAddr(), "localAddrICE", lc.LocalAddr())
+	slog.Debug("Dialed local listener:", "localAddr", lc.RemoteAddr())
 	return
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -228,22 +228,22 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 
 		// proxy requests: local server <- remote client
 		util.Go(cctx, errs, util.Retry(cctx, func() (err error) {
-			slog.Debug("Copying local <- remote:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+			slog.Debug("Copying local <- remote:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
 			nbytes, err := io.Copy(localConn, remoteConn)
-			slog.Debug("Copied local <- remote:", "nbytes", nbytes, "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+			slog.Debug("Copied local <- remote:", "nbytes", nbytes, "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
 			if err == nil {
 				// err == nil means remote connection was closed,
 				// which is not expected so we give up
-				slog.Error("Unexpected EOF reading from remote client:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+				slog.Error("Unexpected EOF reading from remote client:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
 				return util.Permanent(io.EOF)
 			} else if e, ok := err.(*net.OpError); ok && e.Op == "write" {
 				// writing to local connection failed,
 				// so we retry after recreating it
-				slog.Error("Unexpected error writing to local server:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", e)
+				slog.Error("Unexpected error writing to local server:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", e)
 				return util.Permanent(localEOF)
 			} else {
 				// give up
-				slog.Error("Unexpected error copying local <- remote:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", err, "errType", reflect.TypeOf(err))
+				slog.Error("Unexpected error copying local <- remote:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", err, "errType", reflect.TypeOf(err))
 				err = util.Permanent(err)
 			}
 			return
@@ -251,22 +251,22 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 
 		// proxy responses: local server -> remote client
 		util.Go(cctx, errs, util.Retry(cctx, func() (err error) {
-			slog.Debug("Copying local -> remote:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+			slog.Debug("Copying local -> remote:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
 			nbytes, err := io.Copy(remoteConn, localConn)
-			slog.Debug("Copied local -> remote:", "nbytes", nbytes, "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+			slog.Debug("Copied local -> remote:", "nbytes", nbytes, "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
 			if err == nil {
 				// err == nil means local connection was closed,
 				// so we exit and retry after recreating it
-				slog.Error("Unexpected EOF reading from local server:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+				slog.Error("Unexpected EOF reading from local server:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
 				return util.Permanent(localEOF)
 			} else if e, ok := err.(*net.OpError); ok && e.Op == "read" {
 				// another error reading from local conneciton,
 				// so we retry after recreating it
-				slog.Error("Unexpected error reading from local server:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", e)
+				slog.Error("Unexpected error reading from local server:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", e)
 				return util.Permanent(localEOF)
 			} else {
 				// give up
-				slog.Error("Unexpected error copying local -> remote:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", err, "errType", reflect.TypeOf(err))
+				slog.Error("Unexpected error copying local -> remote:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", err, "errType", reflect.TypeOf(err))
 				err = util.Permanent(err)
 			}
 			return
@@ -275,7 +275,7 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 		err = <-errs
 		if errors.Is(err, localEOF) {
 			err = nil
-			slog.Warn("Retrying local connection:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+			slog.Warn("Retrying local connection:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
 			return // retry local connection
 		}
 		return util.Permanent(err)
@@ -311,6 +311,6 @@ func getLocalConn(localAddrs []netip.AddrPort, rc net.Conn) (lc *net.TCPConn, er
 		return
 	}
 	lc = c.(*net.TCPConn)
-	slog.Debug("Dialed local listener:", "localAddr", lc.LocalAddr(), "remoteAddr", lc.RemoteAddr())
+	slog.Debug("Dialed local listener:", "localAddr", lc.RemoteAddr(), "localAddrICE", lc.LocalAddr())
 	return
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -221,7 +221,7 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 		// proxy requests: local server <- remote client
 		util.Go(ctx, errs, util.Retry(ctx, func() (err error) {
 			nbytes, err := io.Copy(localConn, remoteConn)
-			slog.Debug("Copied local <- remote:", "b", nbytes, "err", err)
+			slog.Debug("Copied local <- remote:", "b", nbytes, "local", localConn.RemoteAddr(), "remote", remoteConn.RemoteAddr(), "err", err)
 			if err == io.EOF {
 				return localEOF
 			} else if err == nil {
@@ -233,7 +233,7 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 		// proxy responses: local server -> remote client
 		util.Go(ctx, errs, util.Retry(ctx, func() (err error) {
 			nbytes, err := io.Copy(remoteConn, localConn)
-			slog.Debug("Copied local -> remote:", "b", nbytes, "err", err)
+			slog.Debug("Copied local -> remote:", "b", nbytes, "local", localConn.RemoteAddr(), "remote", remoteConn.RemoteAddr(), "err", err)
 			if err == nil {
 				// err == nil means local connection was closed,
 				// so we should exit and retry after recreating it

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -228,22 +228,22 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 
 		// proxy requests: local server <- remote client
 		util.Go(cctx, errs, util.Retry(cctx, func() (err error) {
-			slog.Debug("Copying local <- remote:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
+			slog.Debug("Copying local <- remote:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
 			nbytes, err := io.Copy(localConn, remoteConn)
-			slog.Debug("Copied local <- remote:", "nbytes", nbytes, "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
+			slog.Debug("Copied local <- remote:", "nbytes", nbytes, "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
 			if err == nil {
 				// err == nil means remote connection was closed,
 				// which is not expected so we give up
-				slog.Error("Unexpected EOF from remote client:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr())
+				slog.Error("Unexpected EOF reading from remote client:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
 				return util.Permanent(io.EOF)
 			} else if e, ok := err.(*net.OpError); ok && e.Op == "write" {
 				// writing to local connection failed,
 				// so we retry after recreating it
-				slog.Error("Unexpected error writing to local server:", "localAddr", localConn.RemoteAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", e)
+				slog.Error("Unexpected error writing to local server:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", e)
 				return util.Permanent(localEOF)
 			} else {
 				// give up
-				slog.Error("Unexpected error copying local <- remote:", "err", err, "errType", reflect.TypeOf(err))
+				slog.Error("Unexpected error copying local <- remote:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr(), "err", err, "errType", reflect.TypeOf(err))
 				err = util.Permanent(err)
 			}
 			return
@@ -257,7 +257,7 @@ func (s *Service) proxyRemoteClient(ctx context.Context, remoteConn net.Conn, lo
 			if err == nil {
 				// err == nil means local connection was closed,
 				// so we exit and retry after recreating it
-				slog.Error("Unexpected EOF from local server:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
+				slog.Error("Unexpected EOF reading from local server:", "localAddr", localConn.RemoteAddr(), "localAddrICE", localConn.LocalAddr(), "remoteAddr", remoteConn.RemoteAddr())
 				return util.Permanent(localEOF)
 			} else if e, ok := err.(*net.OpError); ok && e.Op == "read" {
 				// another error reading from local conneciton,

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -77,10 +77,11 @@ func (s *Service) GetConns(ctx context.Context, peerPID mpc.PID) (_ <-chan net.C
 						slog.Warn("QUIC connection timeout, retrying:", "peerPID", peerPID)
 						err = nil // retry the connection
 					} else if err != nil {
-						slog.Error("TLSConf error:", "peerPID", peerPID, "err", err.Error(), "isClient", s.mpc.IsClient(peerPID))
+						slog.Error("TLSConf error:", "peerPID", peerPID, "err", err.Error(), "isClient", s.mpc.IsClient(peerPID), "isPermanent", util.IsPermanent(err))
 					}
 					return
 				})(); err == errDone {
+					slog.Error("QUIC connection done:", "peerPID", peerPID)
 					err = nil // handle next TLSConf
 				} else if err != nil {
 					slog.Error("quic.GetConns():", "peerPID", peerPID, "err", err.Error())

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"reflect"
 	"time"
 
 	"github.com/quic-go/quic-go"
@@ -77,7 +78,7 @@ func (s *Service) GetConns(ctx context.Context, peerPID mpc.PID) (_ <-chan net.C
 						slog.Warn("QUIC connection timeout, retrying:", "peerPID", peerPID)
 						err = nil // retry the connection
 					} else if err != nil {
-						slog.Error("TLSConf error:", "peerPID", peerPID, "err", err.Error(), "isClient", s.mpc.IsClient(peerPID), "isPermanent", util.IsPermanent(err))
+						slog.Error("TLSConf error:", "peerPID", peerPID, "err", err.Error(), "isClient", s.mpc.IsClient(peerPID), "isPermanent", util.IsPermanent(err), "errType", reflect.TypeOf(err))
 					}
 					return
 				})(); err == errDone {

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -74,7 +74,10 @@ func (s *Service) GetConns(ctx context.Context, peerPID mpc.PID) (_ <-chan net.C
 						err = s.handleServer(ctx, tr, tc.Config, peerPID, conns)
 					}
 					if util.IsTimeout(err) {
+						slog.Warn("QUIC connection timeout, retrying:", "peerPID", peerPID)
 						err = nil // retry the connection
+					} else if err != nil {
+						slog.Error("TLSConf error:", "peerPID", peerPID, "err", err.Error())
 					}
 					return
 				})(); err == errDone {

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -77,7 +77,7 @@ func (s *Service) GetConns(ctx context.Context, peerPID mpc.PID) (_ <-chan net.C
 						slog.Warn("QUIC connection timeout, retrying:", "peerPID", peerPID)
 						err = nil // retry the connection
 					} else if err != nil {
-						slog.Error("TLSConf error:", "peerPID", peerPID, "err", err.Error())
+						slog.Error("TLSConf error:", "peerPID", peerPID, "err", err.Error(), "isClient", s.mpc.IsClient(peerPID))
 					}
 					return
 				})(); err == errDone {

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -143,6 +143,12 @@ type Conn struct {
 	quic.Stream
 }
 
+func (c *Conn) Write(p []byte) (n int, err error) {
+	n, err = c.Stream.Write(p)
+	slog.Debug("Wrote to QUIC stream:", "addr", c.Connection.RemoteAddr(), "n", n, "err", err)
+	return n, err
+}
+
 func (s *Service) handleServer(ctx context.Context, tr *quic.Transport, tlsConf *tls.Config, pid mpc.PID, conns chan<- net.Conn) (err error) {
 	l, err := tr.Listen(tlsConf, s.qConf)
 	if err != nil {

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -111,7 +111,7 @@ func (s *Service) handleClient(ctx context.Context, tr *quic.Transport, tlsConf 
 			slog.Error("Opening QUIC stream:", "peer", pid, "err", err)
 			return
 		}
-		slog.Debug("Opened outgoing QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr())
+		slog.Debug("Opened outgoing QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr(), "nconns", len(conns))
 
 		// non-blocking until len(conns) == s.mpc.Threads
 		conns <- &Conn{Connection: c, Stream: st}
@@ -167,7 +167,7 @@ func (s *Service) handleServerConn(ctx context.Context, pid mpc.PID, conns chan<
 		slog.Error("Accepting QUIC stream:", "err", err)
 		return
 	}
-	slog.Debug("Accepted incoming QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr())
+	slog.Debug("Accepted incoming QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr(), "nconns", len(conns))
 
 	// non-blocking until len(conns) == s.mpc.Threads
 	conns <- &Conn{Connection: c, Stream: st}

--- a/quic/quic.go
+++ b/quic/quic.go
@@ -111,7 +111,7 @@ func (s *Service) handleClient(ctx context.Context, tr *quic.Transport, tlsConf 
 			slog.Error("Opening QUIC stream:", "peer", pid, "err", err)
 			return
 		}
-		slog.Debug("Opened outgoing QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr(), "nconns", len(conns))
+		slog.Debug("Opened outgoing QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr())
 
 		// non-blocking until len(conns) == s.mpc.Threads
 		conns <- &Conn{Connection: c, Stream: st}
@@ -167,7 +167,7 @@ func (s *Service) handleServerConn(ctx context.Context, pid mpc.PID, conns chan<
 		slog.Error("Accepting QUIC stream:", "err", err)
 		return
 	}
-	slog.Debug("Accepted incoming QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr(), "nconns", len(conns))
+	slog.Debug("Accepted incoming QUIC stream:", "peer", pid, "remoteAddr", c.RemoteAddr())
 
 	// non-blocking until len(conns) == s.mpc.Threads
 	conns <- &Conn{Connection: c, Stream: st}

--- a/util/backoff.go
+++ b/util/backoff.go
@@ -27,7 +27,7 @@ func Retry(ctx context.Context, op backoff.Operation) func() error {
 			bCtx := backoff.WithContext(b, ctx)
 
 			if err = backoff.Retry(op, bCtx); err != nil {
-				return
+				return backoff.Permanent(err)
 			}
 		}
 	}

--- a/util/backoff.go
+++ b/util/backoff.go
@@ -40,6 +40,11 @@ func Permanent(err error) error {
 	return backoff.Permanent(err)
 }
 
+func IsPermanent(err error) bool {
+	_, ok := err.(*backoff.PermanentError)
+	return ok
+}
+
 func IsTimeout(err error) bool {
 	if e, ok := err.(*backoff.PermanentError); ok {
 		return IsTimeout(e.Err)


### PR DESCRIPTION
This PR:
* Ignores port mappings in MPC config that don't correspond to client/server role based on PID comparison
* Improve retries and adds more verbose logging for various failure modes
* Limits number of QUIC client streams based on `MpcNumThreads`